### PR TITLE
ci: bump deploy workflow to v0.0.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     if: github.event_name == 'push'
     needs: build
     name: Deploy
-    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@de3f1611b6b8cd6c766ae891f0302b76ce222774 # v0.0.21
+    uses: wajeht/docker-cd-deploy-workflow/.github/workflows/deploy.yaml@071c1838526ef329aea7f37fe2987f64cd76d714 # v0.0.23
     with:
       app-path: apps/screenshot
       service-name: screenshot


### PR DESCRIPTION
Bump wajeht/docker-cd-deploy-workflow to v0.0.23 (digest-pinned deploys).